### PR TITLE
Changed JAXB Implementation dependency from runtime to provided

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -30,7 +30,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/jaxrs-commons/pom.xml
+++ b/jaxrs-commons/pom.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/scl2003/pom.xml
+++ b/scl2003/pom.xml
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/scl2007b/pom.xml
+++ b/scl2007b/pom.xml
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/scl2007b4/pom.xml
+++ b/scl2007b4/pom.xml
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The JAXB Implementation is most of the time already delivered by the application server or framework.
Not always with the same GroupId and ArtifactId, so to prevent conflicts make it provided.