### PR TITLE
Changed the Project Automation GitHub Action

### DIFF
--- a/.github/workflows/automate-projects.yml
+++ b/.github/workflows/automate-projects.yml
@@ -12,31 +12,17 @@ jobs:
 
     if: ${{ (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') || (github.actor == 'dependabot[bot]' && github.event_name == 'pull_request_target') }}
     steps:
-      - name: add-new-issues-to-repository-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
-        if: github.event_name == 'issues' && github.event.action == 'opened'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PROJECT_URL: https://github.com/com-pas/compas-core/projects/2
-          GITHUB_PROJECT_COLUMN_NAME: To do
-      - name: add-new-pull-request-to-repository-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
-        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.action == 'opened'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PROJECT_URL: https://github.com/com-pas/compas-core/projects/2
-          GITHUB_PROJECT_COLUMN_NAME: To do
       - name: add-new-issues-to-organization-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
         if: github.event_name == 'issues' && github.event.action == 'opened'
-        env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
-          GITHUB_PROJECT_URL: https://github.com/orgs/com-pas/projects/1
-          GITHUB_PROJECT_COLUMN_NAME: To do
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: CoMPAS Issues Overview Board
+          column: To do
+          repo-token: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
       - name: add-new-pull-request-to-organization-based-project-column
-        uses: docker://takanabe/github-actions-automate-projects:v0.0.1
         if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.action == 'opened'
-        env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
-          GITHUB_PROJECT_URL: https://github.com/orgs/com-pas/projects/2
-          GITHUB_PROJECT_COLUMN_NAME: To do
+        uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: CoMPAS Pull Request Overview Board
+          column: To do
+          repo-token: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}


### PR DESCRIPTION
The action is now using a new base to execute. This base action is able to handle pull_request_target event, what is needed to put Dependabot PR's on the Project Board.

Also the action is only updating the Project Boards from the Organization, not anymore of the repository. That project board will be removed after this is working correctly.