### PR TITLE
Move method for re-use to support class

### DIFF
--- a/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketHandler.java
+++ b/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketHandler.java
@@ -3,14 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.websocket;
 
-import org.lfenergy.compas.core.commons.exception.CompasException;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.websocket.Session;
 
-import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.WEBSOCKET_GENERAL_ERROR_CODE;
+import static org.lfenergy.compas.core.websocket.WebsocketSupport.handleException;
 
 /**
  * Simple Websocket Handler to handle the result from an executor being called and send this result to the Websocket
@@ -26,21 +25,10 @@ public class WebsocketHandler<T> {
             LOGGER.debug("Executing executor to retrieve response");
             var result = executor.execute();
             session.getAsyncRemote().sendObject(result);
-        } catch (RuntimeException re) {
-            handleException(session, re);
+        } catch (RuntimeException exp) {
+            LOGGER.info("Exception occurred during handling the websocket request", exp);
+            handleException(session, exp);
         }
-    }
-
-    private void handleException(Session session, RuntimeException re) {
-        var response = new ErrorResponse();
-        if (re instanceof CompasException) {
-            LOGGER.info("Handling CompasException thrown by Executor!", re);
-            response.addErrorMessage(((CompasException) re).getErrorCode(), re.getMessage());
-        } else {
-            LOGGER.info("Handling RuntimeException thrown by Executor!", re);
-            response.addErrorMessage(WEBSOCKET_GENERAL_ERROR_CODE, re.getMessage());
-        }
-        session.getAsyncRemote().sendObject(response);
     }
 
     @FunctionalInterface

--- a/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketSupport.java
+++ b/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketSupport.java
@@ -4,13 +4,14 @@
 package org.lfenergy.compas.core.websocket;
 
 import org.lfenergy.compas.core.commons.exception.CompasException;
+import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
+import javax.websocket.Session;
 import javax.xml.bind.JAXBContext;
 import java.io.StringReader;
 import java.io.StringWriter;
 
-import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.WEBSOCKET_DECODER_ERROR_CODE;
-import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.WEBSOCKET_ENCODER_ERROR_CODE;
+import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.*;
 
 public final class WebsocketSupport {
     WebsocketSupport() {
@@ -45,4 +46,13 @@ public final class WebsocketSupport {
         }
     }
 
+    public static void handleException(Session session, RuntimeException re) {
+        var response = new ErrorResponse();
+        if (re instanceof CompasException) {
+            response.addErrorMessage(((CompasException) re).getErrorCode(), re.getMessage());
+        } else {
+            response.addErrorMessage(WEBSOCKET_GENERAL_ERROR_CODE, re.getMessage());
+        }
+        session.getAsyncRemote().sendObject(response);
+    }
 }

--- a/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketSupport.java
+++ b/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketSupport.java
@@ -46,12 +46,12 @@ public final class WebsocketSupport {
         }
     }
 
-    public static void handleException(Session session, RuntimeException re) {
+    public static void handleException(Session session, Throwable throwable) {
         var response = new ErrorResponse();
-        if (re instanceof CompasException) {
-            response.addErrorMessage(((CompasException) re).getErrorCode(), re.getMessage());
+        if (throwable instanceof CompasException) {
+            response.addErrorMessage(((CompasException) throwable).getErrorCode(), throwable.getMessage());
         } else {
-            response.addErrorMessage(WEBSOCKET_GENERAL_ERROR_CODE, re.getMessage());
+            response.addErrorMessage(WEBSOCKET_GENERAL_ERROR_CODE, throwable.getMessage());
         }
         session.getAsyncRemote().sendObject(response);
     }

--- a/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketHandlerTest.java
+++ b/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketHandlerTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class WebsocketHandlerTest {
-
     @Test
     void execute_WhenCalledSuccessful_ThenResponseSendToWebsocket() {
         var message = "Some message";

--- a/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketSupportTest.java
+++ b/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketSupportTest.java
@@ -4,12 +4,122 @@
 package org.lfenergy.compas.core.websocket;
 
 import org.junit.jupiter.api.Test;
+import org.lfenergy.compas.core.commons.exception.CompasException;
+import org.lfenergy.compas.core.commons.model.ErrorResponse;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import javax.websocket.RemoteEndpoint;
+import javax.websocket.Session;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.lfenergy.compas.core.commons.CommonConstants.COMPAS_COMMONS_V1_NS_URI;
+import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.*;
+import static org.lfenergy.compas.core.websocket.WebsocketSupport.*;
+import static org.mockito.Mockito.*;
 
 class WebsocketSupportTest {
     @Test
     void constructor_WhenConstructorCalled_ThenShouldThrowExceptionCauseForbidden() {
         assertThrows(UnsupportedOperationException.class, WebsocketSupport::new);
+    }
+
+    @Test
+    void encode_WhenCalledWithErrorResponse_ThenXMLStringReturned() {
+        var errorCode = "ERR-0001";
+        var errorMessage = "Error Message";
+        var errorResponse = new ErrorResponse();
+        errorResponse.addErrorMessage(errorCode, errorMessage);
+
+        var result = encode(errorResponse, ErrorResponse.class);
+
+        var expectedResult = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<compas-commons:ErrorResponse xmlns:compas-commons=\"" + COMPAS_COMMONS_V1_NS_URI + "\">" +
+                "<compas-commons:ErrorMessage>" +
+                "<compas-commons:Code>" + errorCode + "</compas-commons:Code>" +
+                "<compas-commons:Message>" + errorMessage + "</compas-commons:Message>" +
+                "</compas-commons:ErrorMessage>" +
+                "</compas-commons:ErrorResponse>";
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    void encode_WhenCalledWithNoJaxbObject_ThenExceptionThrown() {
+        var exception = assertThrows(CompasException.class, () -> encode("Some Non JAXB String", String.class));
+        assertEquals(WEBSOCKET_ENCODER_ERROR_CODE, exception.getErrorCode());
+        assertEquals(CompasException.class, exception.getClass());
+    }
+
+    @Test
+    void decode_WhenCalledWithCorrectXML_ThenObjectReturned() {
+        var errorCode = "ERR-0001";
+        var errorMessage = "Error Message";
+
+        var xmlMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<compas-commons:ErrorResponse xmlns:compas-commons=\"" + COMPAS_COMMONS_V1_NS_URI + "\">" +
+                "<compas-commons:ErrorMessage>" +
+                "<compas-commons:Code>" + errorCode + "</compas-commons:Code>" +
+                "<compas-commons:Message>" + errorMessage + "</compas-commons:Message>" +
+                "</compas-commons:ErrorMessage>" +
+                "</compas-commons:ErrorResponse>";
+
+        var result = decode(xmlMessage, ErrorResponse.class);
+
+        assertNotNull(result);
+        assertEquals(1, result.getErrorMessages().size());
+        var message = result.getErrorMessages().get(0);
+        assertEquals(errorCode, message.getCode());
+        assertEquals(errorMessage, message.getMessage());
+    }
+
+
+    @Test
+    void decode_WhenCalledWithInvalidXML_ThenExceptionThrown() {
+        var xmlMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<compas-commons:InvalidResponse xmlns:compas-commons=\"" + COMPAS_COMMONS_V1_NS_URI + "\">" +
+                "</compas-commons:InvalidResponse>";
+
+        var exception = assertThrows(CompasException.class, () -> decode(xmlMessage, ErrorResponse.class));
+        assertEquals(WEBSOCKET_DECODER_ERROR_CODE, exception.getErrorCode());
+        assertEquals(CompasException.class, exception.getClass());
+    }
+
+    @Test
+    void handleException_WhenCalledWithCompasException_ThenErrorResponseSendToSession() {
+        var errorCode = "ERR-0001";
+        var errorMessage = "Error Message";
+        var session = mockSession();
+
+        handleException(session, new CompasException(errorCode, errorMessage));
+
+        verifyErrorResponse(session, errorCode, errorMessage);
+    }
+
+    @Test
+    void handleException_WhenCalledWithRuntimeException_ThenErrorResponseSendToSession() {
+        var errorMessage = "Error Message";
+        var session = mockSession();
+
+        handleException(session, new RuntimeException(errorMessage));
+
+        verifyErrorResponse(session, WEBSOCKET_GENERAL_ERROR_CODE, errorMessage);
+    }
+
+    private Session mockSession() {
+        var session = Mockito.mock(Session.class);
+        var async = Mockito.mock(RemoteEndpoint.Async.class);
+        when(session.getAsyncRemote()).thenReturn(async);
+        return session;
+    }
+
+    private void verifyErrorResponse(Session session, String errorCode, String errorMessage) {
+        verify(session, times(1)).getAsyncRemote();
+        ArgumentCaptor<ErrorResponse> captor = ArgumentCaptor.forClass(ErrorResponse.class);
+        verify(session.getAsyncRemote(), times(1)).sendObject(captor.capture());
+        var response = captor.getValue();
+        assertEquals(1, response.getErrorMessages().size());
+        var message = response.getErrorMessages().get(0);
+        assertEquals(errorCode, message.getCode());
+        assertEquals(errorMessage, message.getMessage());
     }
 }


### PR DESCRIPTION
Moving the HandleException method to the WebsocketSupport class makes it possible to use this method also in the Server Endpoint in the onError method to send a ErrorResponse to the Client if something went wrong in the Websocket.