### PR TITLE
Remove validation in Decoder for Websocket

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,13 +28,6 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 5
     ignore:
-      # Next two dependencies shouldn't be upgrade, because Quarkus isn't using newer version of EL.
-      - dependency-name: org.hibernate.validator:hibernate-validator
-        versions: [ "[7.0,)" ]
-      - dependency-name: org.glassfish:jakarta.el
-        versions: [ "[4.0,)" ]
-      # Next two dependencies shouldn't be upgrade, because RestEasy isn't using newer version. (2.3.X)
-      - dependency-name: jakarta.xml.bind:jakarta.xml.bind-api
-        versions: [ "[3.0,)" ]
+      # Next dependencies shouldn't be upgrade, because RestEasy isn't using newer version. (2.3.X)
       - dependency-name: com.sun.xml.bind:jaxb-impl
         versions: [ "[3.0,)" ]

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -48,6 +48,12 @@ SPDX-License-Identifier: Apache-2.0
         </dependency>
 
         <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
@@ -65,11 +71,6 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/websocket-commons/pom.xml
+++ b/websocket-commons/pom.xml
@@ -24,10 +24,6 @@ SPDX-License-Identifier: Apache-2.0
         </dependency>
 
         <dependency>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
         </dependency>
@@ -39,6 +35,12 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -55,22 +57,6 @@ SPDX-License-Identifier: Apache-2.0
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-mockito</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketSupport.java
+++ b/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketSupport.java
@@ -7,7 +7,6 @@ import org.lfenergy.compas.core.commons.exception.CompasException;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
 import javax.validation.ConstraintViolationException;
-import javax.validation.Validation;
 import javax.websocket.Session;
 import javax.xml.bind.JAXBContext;
 import java.io.StringReader;
@@ -40,19 +39,7 @@ public final class WebsocketSupport {
             var jaxbContext = JAXBContext.newInstance(jaxbClass);
             var unmarshaller = jaxbContext.createUnmarshaller();
             var reader = new StringReader(message);
-            var jaxbObject = jaxbClass.cast(unmarshaller.unmarshal(reader));
-
-            try (var factory = Validation.buildDefaultValidatorFactory()) {
-                var validator = factory.getValidator();
-                var constraintViolations = validator.validate(jaxbObject);
-                if (!constraintViolations.isEmpty()) {
-                    throw new ConstraintViolationException(constraintViolations);
-                }
-            }
-
-            return jaxbObject;
-        } catch (ConstraintViolationException exp) {
-            throw exp;
+            return jaxbClass.cast(unmarshaller.unmarshal(reader));
         } catch (Exception exp) {
             throw new CompasException(WEBSOCKET_DECODER_ERROR_CODE,
                     "Error unmarshalling to class '" + jaxbClass.getName() + "' from Websockets.",

--- a/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketSupportTest.java
+++ b/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketSupportTest.java
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.websocket;
 
-import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.lfenergy.compas.core.commons.exception.CompasException;
@@ -14,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
+import javax.validation.Path;
 import javax.websocket.RemoteEndpoint;
 import javax.websocket.Session;
 import java.util.Set;
@@ -80,19 +80,6 @@ class WebsocketSupportTest {
     }
 
     @Test
-    void decode_WhenCalledWithValidationErrors_ThenConstraintViolationExceptionThrown() {
-        var xmlMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
-                "<compas-commons:ErrorResponse xmlns:compas-commons=\"" + COMPAS_COMMONS_V1_NS_URI + "\">" +
-                "<compas-commons:ErrorMessage>" +
-                "<compas-commons:Message>Some message</compas-commons:Message>" +
-                "</compas-commons:ErrorMessage>" +
-                "</compas-commons:ErrorResponse>";
-
-        var exception = assertThrows(ConstraintViolationException.class, () -> decode(xmlMessage, ErrorResponse.class));
-        assertEquals(1, exception.getConstraintViolations().size());
-    }
-
-    @Test
     void decode_WhenCalledWithInvalidXML_ThenExceptionThrown() {
         var xmlMessage = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
                 "<compas-commons:InvalidResponse xmlns:compas-commons=\"" + COMPAS_COMMONS_V1_NS_URI + "\">" +
@@ -119,9 +106,9 @@ class WebsocketSupportTest {
         var session = mockSession();
 
         var errorMessage = "Error Message";
-        var path = PathImpl.createRootPath();
 
         ConstraintViolation<String> constraintViolation = mock(ConstraintViolation.class);
+        Path path = mock(Path.class);
         when(constraintViolation.getMessage()).thenReturn(errorMessage);
         when(constraintViolation.getPropertyPath()).thenReturn(path);
 


### PR DESCRIPTION
There is a better way in Quarkus to validate the incoming request.
This can be done by adding @Valid to the incoming message parameter.
This way the request is automatically validated and the error is also send back to the client as XML automatically.

Remark: cleanup of dependabot configuration, because these dependencies are not there anymore.