### PR TITLE
Migrating to Quarkus 3.0

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -48,9 +48,10 @@ SPDX-License-Identifier: Apache-2.0
         </dependency>
 
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>provided</scope>
+            <version>4.0.2</version>
         </dependency>
 
         <dependency>
@@ -68,9 +69,9 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>hibernate-validator</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
+        <!--~~(No version provided)~~>--><dependency>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/commons/src/main/java/org/lfenergy/compas/core/commons/MarshallerWrapper.java
+++ b/commons/src/main/java/org/lfenergy/compas/core/commons/MarshallerWrapper.java
@@ -13,10 +13,10 @@ import org.lfenergy.compas.core.commons.exception.CompasException;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;

--- a/commons/src/main/java/org/lfenergy/compas/core/commons/constraint/FilenameValid.java
+++ b/commons/src/main/java/org/lfenergy/compas/core/commons/constraint/FilenameValid.java
@@ -5,8 +5,8 @@ package org.lfenergy.compas.core.commons.constraint;
 
 import org.lfenergy.compas.core.commons.constraint.impl.FilenameConstraintValidator;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/commons/src/main/java/org/lfenergy/compas/core/commons/constraint/XmlAnyElementValid.java
+++ b/commons/src/main/java/org/lfenergy/compas/core/commons/constraint/XmlAnyElementValid.java
@@ -5,8 +5,8 @@ package org.lfenergy.compas.core.commons.constraint;
 
 import org.lfenergy.compas.core.commons.constraint.impl.XmlAnyElementConstraintValidator;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/commons/src/main/java/org/lfenergy/compas/core/commons/constraint/impl/FilenameConstraintValidator.java
+++ b/commons/src/main/java/org/lfenergy/compas/core/commons/constraint/impl/FilenameConstraintValidator.java
@@ -5,8 +5,8 @@ package org.lfenergy.compas.core.commons.constraint.impl;
 
 import org.lfenergy.compas.core.commons.constraint.FilenameValid;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/commons/src/main/java/org/lfenergy/compas/core/commons/constraint/impl/XmlAnyElementConstraintValidator.java
+++ b/commons/src/main/java/org/lfenergy/compas/core/commons/constraint/impl/XmlAnyElementConstraintValidator.java
@@ -8,8 +8,8 @@ import org.apache.logging.log4j.Logger;
 import org.lfenergy.compas.core.commons.constraint.XmlAnyElementValid;
 import org.w3c.dom.Element;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.List;
 
 /**

--- a/commons/src/main/java/org/lfenergy/compas/core/commons/model/ErrorMessage.java
+++ b/commons/src/main/java/org/lfenergy/compas/core/commons/model/ErrorMessage.java
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.commons.model;
 
-import javax.validation.constraints.NotBlank;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
 
 import static org.lfenergy.compas.core.commons.CommonConstants.COMPAS_COMMONS_V1_NS_URI;
 

--- a/commons/src/main/java/org/lfenergy/compas/core/commons/model/ErrorResponse.java
+++ b/commons/src/main/java/org/lfenergy/compas/core/commons/model/ErrorResponse.java
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.commons.model;
 
-import javax.validation.Valid;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.validation.Valid;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/commons/src/main/java/org/lfenergy/compas/core/commons/model/package-info.java
+++ b/commons/src/main/java/org/lfenergy/compas/core/commons/model/package-info.java
@@ -4,7 +4,7 @@
 @XmlSchema(xmlns = {@XmlNs(prefix = "compas-commons", namespaceURI = COMPAS_COMMONS_V1_NS_URI)})
 package org.lfenergy.compas.core.commons.model;
 
-import javax.xml.bind.annotation.XmlNs;
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlNs;
+import jakarta.xml.bind.annotation.XmlSchema;
 
 import static org.lfenergy.compas.core.commons.CommonConstants.COMPAS_COMMONS_V1_NS_URI;

--- a/commons/src/test/java/org/lfenergy/compas/core/commons/MarshallerWrapperTest.java
+++ b/commons/src/test/java/org/lfenergy/compas/core/commons/MarshallerWrapperTest.java
@@ -8,8 +8,8 @@ import org.lfenergy.compas.core.commons.exception.CompasException;
 import org.lfenergy.compas.core.commons.model.XmlElementAPojo;
 import org.lfenergy.compas.core.commons.model.XmlElementBPojo;
 
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/commons/src/test/java/org/lfenergy/compas/core/commons/constraint/impl/FilenameConstraintValidatorTest.java
+++ b/commons/src/test/java/org/lfenergy/compas/core/commons/constraint/impl/FilenameConstraintValidatorTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.core.commons.constraint.FilenameValid;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/commons/src/test/java/org/lfenergy/compas/core/commons/constraint/impl/XmlAnyElementConstraintValidatorTest.java
+++ b/commons/src/test/java/org/lfenergy/compas/core/commons/constraint/impl/XmlAnyElementConstraintValidatorTest.java
@@ -9,8 +9,8 @@ import org.lfenergy.compas.core.commons.constraint.XmlAnyElementValid;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.util.ArrayList;

--- a/commons/src/test/java/org/lfenergy/compas/core/commons/model/ObjectFactory.java
+++ b/commons/src/test/java/org/lfenergy/compas/core/commons/model/ObjectFactory.java
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.commons.model;
 
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.annotation.XmlElementDecl;
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.annotation.XmlElementDecl;
+import jakarta.xml.bind.annotation.XmlRegistry;
 import javax.xml.namespace.QName;
 
 @XmlRegistry

--- a/commons/src/test/java/org/lfenergy/compas/core/commons/model/XmlElementAPojo.java
+++ b/commons/src/test/java/org/lfenergy/compas/core/commons/model/XmlElementAPojo.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.commons.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "XmlElementAPojo")

--- a/commons/src/test/java/org/lfenergy/compas/core/commons/model/XmlElementBPojo.java
+++ b/commons/src/test/java/org/lfenergy/compas/core/commons/model/XmlElementBPojo.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.commons.model;
 
-import javax.xml.bind.annotation.*;
+import jakarta.xml.bind.annotation.*;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "XmlElementBPojo")

--- a/commons/src/test/java/org/lfenergy/compas/core/commons/model/package-info.java
+++ b/commons/src/test/java/org/lfenergy/compas/core/commons/model/package-info.java
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2021 Alliander N.V.
 //
 // SPDX-License-Identifier: Apache-2.0
-@XmlSchema(namespace = "https://www.lfenergy.org/compas/example", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@XmlSchema(namespace = "https://www.lfenergy.org/compas/example", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.lfenergy.compas.core.commons.model;
 
-import javax.xml.bind.annotation.XmlSchema;
+import jakarta.xml.bind.annotation.XmlSchema;

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,7 @@ SPDX-License-Identifier: Apache-2.0
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <compas.scl.xsd.version>0.0.4</compas.scl.xsd.version>
-        <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>
-        <jaxb.bind.version>2.3.8</jaxb.bind.version>
+        <quarkus.platform.version>3.0.4.Final</quarkus.platform.version>
         <log4j2.version>2.20.0</log4j2.version>
         <openpojo.version>0.9.1</openpojo.version>
     </properties>
@@ -54,8 +53,8 @@ SPDX-License-Identifier: Apache-2.0
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-bom</artifactId>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -75,12 +74,6 @@ SPDX-License-Identifier: Apache-2.0
                 <groupId>org.lfenergy.compas.xsd</groupId>
                 <artifactId>compas-scl-xsd</artifactId>
                 <version>${compas.scl.xsd.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb.bind.version}</version>
             </dependency>
 
             <dependency>
@@ -119,14 +112,14 @@ SPDX-License-Identifier: Apache-2.0
                 </plugin>
 
                 <plugin>
-                    <groupId>org.jvnet.jaxb2.maven2</groupId>
-                    <artifactId>maven-jaxb2-plugin</artifactId>
-                    <version>0.15.3</version>
+                    <groupId>com.helger.maven</groupId>
+                    <artifactId>jaxb40-maven-plugin</artifactId>
+                    <version>0.16.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.jvnet.jaxb2_commons</groupId>
                             <artifactId>jaxb2-namespace-prefix</artifactId>
-                            <version>1.3</version>
+                            <version>2.0</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/rest-commons/pom.xml
+++ b/rest-commons/pom.xml
@@ -24,8 +24,9 @@ SPDX-License-Identifier: Apache-2.0
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
         </dependency>
 
         <dependency>

--- a/rest-commons/src/main/java/org/lfenergy/compas/core/rest/exception/CompasExceptionHandler.java
+++ b/rest-commons/src/main/java/org/lfenergy/compas/core/rest/exception/CompasExceptionHandler.java
@@ -8,9 +8,9 @@ import org.apache.logging.log4j.Logger;
 import org.lfenergy.compas.core.commons.exception.CompasException;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class CompasExceptionHandler implements ExceptionMapper<CompasException> {

--- a/rest-commons/src/main/java/org/lfenergy/compas/core/rest/exception/ConstraintViolationExceptionHandler.java
+++ b/rest-commons/src/main/java/org/lfenergy/compas/core/rest/exception/ConstraintViolationExceptionHandler.java
@@ -7,10 +7,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
-import javax.validation.ConstraintViolationException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.VALIDATION_ERROR;
 

--- a/rest-commons/src/main/java/org/lfenergy/compas/core/rest/exception/GenericExceptionHandler.java
+++ b/rest-commons/src/main/java/org/lfenergy/compas/core/rest/exception/GenericExceptionHandler.java
@@ -7,9 +7,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 
 import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.UNKNOWN_EXCEPTION_ERROR;
 

--- a/rest-commons/src/test/java/org/lfenergy/compas/core/rest/exception/CompasExceptionHandlerTest.java
+++ b/rest-commons/src/test/java/org/lfenergy/compas/core/rest/exception/CompasExceptionHandlerTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.core.commons.exception.CompasException;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.NO_CLASS_LOADER_ERROR_CODE;

--- a/rest-commons/src/test/java/org/lfenergy/compas/core/rest/exception/ConstraintViolationExceptionHandlerTest.java
+++ b/rest-commons/src/test/java/org/lfenergy/compas/core/rest/exception/ConstraintViolationExceptionHandlerTest.java
@@ -9,12 +9,12 @@ import org.lfenergy.compas.core.commons.model.ErrorResponse;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Path;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
 import java.util.HashSet;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.VALIDATION_ERROR;

--- a/rest-commons/src/test/java/org/lfenergy/compas/core/rest/exception/GenericExceptionHandlerTest.java
+++ b/rest-commons/src/test/java/org/lfenergy/compas/core/rest/exception/GenericExceptionHandlerTest.java
@@ -6,7 +6,7 @@ package org.lfenergy.compas.core.rest.exception;
 import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
-import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.UNKNOWN_EXCEPTION_ERROR;

--- a/scl-extension/pom.xml
+++ b/scl-extension/pom.xml
@@ -53,9 +53,8 @@ SPDX-License-Identifier: Apache-2.0
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
-                <version>0.15.3</version>
+                <groupId>com.helger.maven</groupId>
+                <artifactId>jaxb40-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>xjc</id>

--- a/scl-extension/src/main/bindings/scl-extensions.xjb
+++ b/scl-extension/src/main/bindings/scl-extensions.xjb
@@ -5,8 +5,8 @@ SPDX-FileCopyrightText: 2021 Alliander N.V.
 SPDX-License-Identifier: Apache-2.0
 -->
 <jxb:bindings xmlns:xs="http://www.w3.org/2001/XMLSchema"
-              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
-              version="2.1">
+              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
+              version="3.0">
     <jxb:bindings schemaLocation="../resources/xsd/SCL_CoMPAS.xsd">
         <jxb:bindings node="//xs:simpleType[@name='tCompasSclFileType']">
             <jxb:typesafeEnumClass ref="org.lfenergy.compas.scl.extensions.model.SclFileType"/>

--- a/scl-extension/src/main/java/org/lfenergy/compas/scl/extensions/commons/AbstractCompasExtensionsManager.java
+++ b/scl-extension/src/main/java/org/lfenergy/compas/scl/extensions/commons/AbstractCompasExtensionsManager.java
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.extensions.commons;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Optional;

--- a/scl-extension/src/main/java/org/lfenergy/compas/scl/extensions/model/SclFileType.java
+++ b/scl-extension/src/main/java/org/lfenergy/compas/scl/extensions/model/SclFileType.java
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.scl.extensions.model;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlType;
 
 import static org.lfenergy.compas.scl.extensions.commons.CompasExtensionsConstants.COMPAS_EXTENSION_NS_URI;
 

--- a/scl-extension/src/test/java/org/lfenergy/compas/scl/extensions/commons/AbstractCompasExtensionsManagerTest.java
+++ b/scl-extension/src/test/java/org/lfenergy/compas/scl/extensions/commons/AbstractCompasExtensionsManagerTest.java
@@ -5,7 +5,7 @@ package org.lfenergy.compas.scl.extensions.commons;
 
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 import java.util.ArrayList;
 import java.util.List;

--- a/scl2003/pom.xml
+++ b/scl2003/pom.xml
@@ -40,9 +40,10 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>provided</scope>
+            <version>4.0.2</version>
         </dependency>
 
         <dependency>
@@ -94,8 +95,8 @@ SPDX-License-Identifier: Apache-2.0
             </plugin>
 
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
+                <groupId>com.helger.maven</groupId>
+                <artifactId>jaxb40-maven-plugin</artifactId>
                 <configuration>
                     <generatePackage>org.lfenergy.compas.scl2003.model</generatePackage>
                     <schemaDirectory>${project.build.directory}/xsd/SCL2003</schemaDirectory>

--- a/scl2003/src/main/bindings/scl2003.xjb
+++ b/scl2003/src/main/bindings/scl2003.xjb
@@ -4,8 +4,8 @@ SPDX-FileCopyrightText: 2021 Alliander N.V.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<jxb:bindings version="1.0"
-              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+<jxb:bindings version="3.0"
+              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
               xmlns:namespace="http://jaxb2-commons.dev.java.net/namespace-prefix"
               xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <jxb:bindings schemaLocation="../../../target/xsd/SCL2003/SCL.xsd" node="/xs:schema">

--- a/scl2003/src/main/java/org/lfenergy/compas/scl2003/commons/CompasExtensionsManager.java
+++ b/scl2003/src/main/java/org/lfenergy/compas/scl2003/commons/CompasExtensionsManager.java
@@ -10,7 +10,7 @@ import org.lfenergy.compas.scl.extensions.model.TCompasLabels;
 import org.lfenergy.compas.scl2003.model.SCL;
 import org.lfenergy.compas.scl2003.model.TPrivate;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import java.util.Optional;
 
 import static org.lfenergy.compas.scl.extensions.commons.CompasExtensionsConstants.COMPAS_SCL_EXTENSION_TYPE;

--- a/scl2003/src/main/java/org/lfenergy/compas/scl2003/commons/Scl2003MarshallerWrapper.java
+++ b/scl2003/src/main/java/org/lfenergy/compas/scl2003/commons/Scl2003MarshallerWrapper.java
@@ -6,8 +6,8 @@ package org.lfenergy.compas.scl2003.commons;
 import org.lfenergy.compas.core.commons.MarshallerWrapper;
 import org.lfenergy.compas.scl2003.model.SCL;
 
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 public class Scl2003MarshallerWrapper extends MarshallerWrapper<SCL> {
     public Scl2003MarshallerWrapper(Unmarshaller jaxbUnmarshaller, Marshaller jaxbMarshaller) {

--- a/scl2007b/pom.xml
+++ b/scl2007b/pom.xml
@@ -40,9 +40,10 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>provided</scope>
+            <version>4.0.2</version>
         </dependency>
 
         <dependency>
@@ -94,8 +95,8 @@ SPDX-License-Identifier: Apache-2.0
             </plugin>
 
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
+                <groupId>com.helger.maven</groupId>
+                <artifactId>jaxb40-maven-plugin</artifactId>
                 <configuration>
                     <generatePackage>org.lfenergy.compas.scl2007b.model</generatePackage>
                     <schemaDirectory>${project.build.directory}/xsd/SCL2007B</schemaDirectory>

--- a/scl2007b/src/main/bindings/scl2007b.xjb
+++ b/scl2007b/src/main/bindings/scl2007b.xjb
@@ -4,8 +4,8 @@ SPDX-FileCopyrightText: 2021 Alliander N.V.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<jxb:bindings version="1.0"
-              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+<jxb:bindings version="3.0"
+              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
               xmlns:namespace="http://jaxb2-commons.dev.java.net/namespace-prefix"
               xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <jxb:bindings schemaLocation="../../../target/xsd/SCL2007B/SCL.xsd" node="/xs:schema">

--- a/scl2007b/src/main/java/org/lfenergy/compas/scl2007b/commons/CompasExtensionsManager.java
+++ b/scl2007b/src/main/java/org/lfenergy/compas/scl2007b/commons/CompasExtensionsManager.java
@@ -10,7 +10,7 @@ import org.lfenergy.compas.scl.extensions.model.TCompasLabels;
 import org.lfenergy.compas.scl2007b.model.SCL;
 import org.lfenergy.compas.scl2007b.model.TPrivate;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import java.util.Optional;
 
 import static org.lfenergy.compas.scl.extensions.commons.CompasExtensionsConstants.COMPAS_SCL_EXTENSION_TYPE;

--- a/scl2007b/src/main/java/org/lfenergy/compas/scl2007b/commons/Scl2007bMarshallerWrapper.java
+++ b/scl2007b/src/main/java/org/lfenergy/compas/scl2007b/commons/Scl2007bMarshallerWrapper.java
@@ -6,8 +6,8 @@ package org.lfenergy.compas.scl2007b.commons;
 import org.lfenergy.compas.core.commons.MarshallerWrapper;
 import org.lfenergy.compas.scl2007b.model.SCL;
 
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 public class Scl2007bMarshallerWrapper extends MarshallerWrapper<SCL> {
     public Scl2007bMarshallerWrapper(Unmarshaller jaxbUnmarshaller, Marshaller jaxbMarshaller) {

--- a/scl2007b4/pom.xml
+++ b/scl2007b4/pom.xml
@@ -40,9 +40,10 @@ SPDX-License-Identifier: Apache-2.0
             <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>provided</scope>
+            <version>4.0.2</version>
         </dependency>
 
         <dependency>
@@ -94,8 +95,8 @@ SPDX-License-Identifier: Apache-2.0
             </plugin>
 
             <plugin>
-                <groupId>org.jvnet.jaxb2.maven2</groupId>
-                <artifactId>maven-jaxb2-plugin</artifactId>
+                <groupId>com.helger.maven</groupId>
+                <artifactId>jaxb40-maven-plugin</artifactId>
                 <configuration>
                     <generatePackage>org.lfenergy.compas.scl2007b4.model</generatePackage>
                     <schemaDirectory>${project.build.directory}/xsd/SCL2007B4</schemaDirectory>

--- a/scl2007b4/src/main/bindings/scl2007b4.xjb
+++ b/scl2007b4/src/main/bindings/scl2007b4.xjb
@@ -4,8 +4,8 @@ SPDX-FileCopyrightText: 2021 Alliander N.V.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<jxb:bindings version="1.0"
-              xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+<jxb:bindings version="3.0"
+              xmlns:jxb="https://jakarta.ee/xml/ns/jaxb"
               xmlns:namespace="http://jaxb2-commons.dev.java.net/namespace-prefix"
               xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <jxb:bindings schemaLocation="../../../target/xsd/SCL2007B4/SCL.xsd" node="/xs:schema">

--- a/scl2007b4/src/main/java/org/lfenergy/compas/scl2007b4/commons/CompasExtensionsManager.java
+++ b/scl2007b4/src/main/java/org/lfenergy/compas/scl2007b4/commons/CompasExtensionsManager.java
@@ -10,7 +10,7 @@ import org.lfenergy.compas.scl.extensions.model.TCompasLabels;
 import org.lfenergy.compas.scl2007b4.model.SCL;
 import org.lfenergy.compas.scl2007b4.model.TPrivate;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import java.util.Optional;
 
 import static org.lfenergy.compas.scl.extensions.commons.CompasExtensionsConstants.COMPAS_SCL_EXTENSION_TYPE;

--- a/scl2007b4/src/main/java/org/lfenergy/compas/scl2007b4/commons/Scl2007b4MarshallerWrapper.java
+++ b/scl2007b4/src/main/java/org/lfenergy/compas/scl2007b4/commons/Scl2007b4MarshallerWrapper.java
@@ -6,8 +6,8 @@ package org.lfenergy.compas.scl2007b4.commons;
 import org.lfenergy.compas.core.commons.MarshallerWrapper;
 import org.lfenergy.compas.scl2007b4.model.SCL;
 
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
 
 public class Scl2007b4MarshallerWrapper extends MarshallerWrapper<SCL> {
     public Scl2007b4MarshallerWrapper(Unmarshaller jaxbUnmarshaller, Marshaller jaxbMarshaller) {

--- a/websocket-commons/pom.xml
+++ b/websocket-commons/pom.xml
@@ -24,8 +24,8 @@ SPDX-License-Identifier: Apache-2.0
         </dependency>
 
         <dependency>
-            <groupId>jakarta.websocket</groupId>
-            <artifactId>jakarta.websocket-api</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets</artifactId>
         </dependency>
 
         <dependency>
@@ -39,9 +39,10 @@ SPDX-License-Identifier: Apache-2.0
         </dependency>
 
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
             <scope>provided</scope>
+            <version>4.0.2</version>
         </dependency>
 
         <dependency>

--- a/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/AbstractDecoder.java
+++ b/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/AbstractDecoder.java
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.websocket;
 
-import javax.websocket.Decoder;
-import javax.websocket.EndpointConfig;
+import jakarta.websocket.Decoder;
+import jakarta.websocket.EndpointConfig;
 
 /**
  * Simple abstract class to save some boilerplate code with common implementations.

--- a/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/AbstractEncoder.java
+++ b/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/AbstractEncoder.java
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.lfenergy.compas.core.websocket;
 
-import javax.websocket.Encoder;
-import javax.websocket.EndpointConfig;
+import jakarta.websocket.Encoder;
+import jakarta.websocket.EndpointConfig;
 
 /**
  * Simple abstract class to save some boilerplate code with common implementations.

--- a/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketHandler.java
+++ b/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketHandler.java
@@ -7,7 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
-import javax.websocket.Session;
+import jakarta.websocket.Session;
 
 import static org.lfenergy.compas.core.websocket.WebsocketSupport.handleException;
 

--- a/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketSupport.java
+++ b/websocket-commons/src/main/java/org/lfenergy/compas/core/websocket/WebsocketSupport.java
@@ -6,9 +6,9 @@ package org.lfenergy.compas.core.websocket;
 import org.lfenergy.compas.core.commons.exception.CompasException;
 import org.lfenergy.compas.core.commons.model.ErrorResponse;
 
-import javax.validation.ConstraintViolationException;
-import javax.websocket.Session;
-import javax.xml.bind.JAXBContext;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.websocket.Session;
+import jakarta.xml.bind.JAXBContext;
 import java.io.StringReader;
 import java.io.StringWriter;
 

--- a/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/ErrorResponseDecoderTest.java
+++ b/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/ErrorResponseDecoderTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.lfenergy.compas.core.commons.exception.CompasException;
 
-import javax.xml.bind.UnmarshalException;
+import jakarta.xml.bind.UnmarshalException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.lfenergy.compas.core.commons.CommonConstants.COMPAS_COMMONS_V1_NS_URI;

--- a/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketHandlerTest.java
+++ b/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketHandlerTest.java
@@ -11,8 +11,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.websocket.RemoteEndpoint;
-import javax.websocket.Session;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.lfenergy.compas.core.commons.exception.CompasErrorCode.WEBSOCKET_GENERAL_ERROR_CODE;

--- a/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketSupportTest.java
+++ b/websocket-commons/src/test/java/org/lfenergy/compas/core/websocket/WebsocketSupportTest.java
@@ -11,11 +11,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Path;
-import javax.websocket.RemoteEndpoint;
-import javax.websocket.Session;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
the main change is migrating from JavaEE to JakartaEE.

- update Quarkus bom from `io.quarkus:quarkus-universe-bom` to `io.quarkus.platform:quarkus-bom` as it was deprecated since Quarkus 2.1
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.1#quarkus-universe-bom-is-deprecated (and it is required to use the Quarkus migration tool)
- launched quarkus `quarkus update --stream=3.0` as mentioned in https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.0#automatic-update-tool which dealt with a fair part of the migration. Then it remained few little tasks.
- Updated one package-info annotation
- Updated from `jakarta.websocket:jakarta.websocket-api` to `io.quarkus:quarkus-websockets` (another alternatives might be to add jakarta.websocket:jakarta.websocket-client-api)
- Updated Jaxb generation. Moving from `org.jvnet.jaxb2.maven2:maven-jaxb2-plugin` to `com.helger.maven:jaxb40-maven-plugin`. Jaxb 3+ is supporting Jakarta. Using a fork which has implemented the support of Jacxb4. The initial repository is not very active despite issue raised and a PR is proposed: see https://github.com/highsource/maven-jaxb2-plugin/issues/253

it remains some javax packages. they are javax.xml. i tis still part of the JDK so no need of migration

I guess it is a change that requires a major version upgrades.
Should I increment the versions in this PR or do it in a separate PR?

Also, i think it is impacting almost all other com-pas projects;maybe better to prepare PR for all other repositories before merging this one.